### PR TITLE
Remove required ruby version from gem spec

### DIFF
--- a/wdm.gemspec
+++ b/wdm.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '0.1.0'
 
-  gem.required_ruby_version = '>= 1.9.2'
-
   gem.add_development_dependency 'rake-compiler'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'guard-rspec'


### PR DESCRIPTION
This allow `wdm` to be installed by `Listen` users on 1.8 even if `wdm` will not work with it. More info: https://github.com/guard/listen/pull/97