### PR TITLE
Fix compiling with VS2013/Ruby 2.1.2

### DIFF
--- a/ext/wdm/extconf.rb
+++ b/ext/wdm/extconf.rb
@@ -21,6 +21,7 @@ if windows? and
    have_header("ruby.h")    and
    have_const('HAVE_RUBY_ENCODING_H')
 then
+   have_func('rb_thread_call_without_gvl')
    generate_makefile()
 else
   generate_dummy_makefile() 

--- a/ext/wdm/rb_monitor.c
+++ b/ext/wdm/rb_monitor.c
@@ -210,9 +210,6 @@ combined_watch(BOOL recursively, int argc, VALUE *argv, VALUE self)
         rb_raise(eWDM_InvalidDirectoryError, "No such directory: '%s'!", RSTRING_PTR(directory));
     }
 
-    // Tell the GC to collect the tmp string
-    rb_str_resize(os_encoded_directory, 0);
-
     entry->dir_handle = CreateFileW(
         entry->user_data->dir,     // pointer to the file name
         FILE_LIST_DIRECTORY,       // access (read/write) mode

--- a/ext/wdm/rb_monitor.c
+++ b/ext/wdm/rb_monitor.c
@@ -502,7 +502,11 @@ rb_monitor_run_bang(VALUE self)
     }
 
     while ( monitor->running ) {
+#ifdef HAVE_RB_THREAD_CALL_WITHOUT_GVL
+        waiting_succeeded = rb_thread_call_without_gvl(wait_for_changes, monitor->process_event, stop_monitoring, monitor);
+#else
         waiting_succeeded = rb_thread_blocking_region(wait_for_changes, monitor->process_event, stop_monitoring, monitor);
+#endif
 
         if ( waiting_succeeded == Qfalse ) {
             rb_raise(eWDM_Error, "Failed while waiting for a change in the watched directories!");

--- a/ext/wdm/wdm.h
+++ b/ext/wdm/wdm.h
@@ -3,6 +3,10 @@
 #define WINVER 0x0500       // Support Windows 2000 and later,
 #define _WIN32_WINNT 0x0500 // this is needed for 'GetLongPathNameW'
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #ifndef VC_EXTRALEAN
 #define VC_EXTRALEAN        // Exclude rarely-used stuff from Windows headers
 #endif


### PR DESCRIPTION
Later VS compilers when compiling from the command line would complain because WinSock2 and WinSock are both included.