### PR TITLE
Appveyor.yml added for integration testing on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+---
+version: '{build}'
+
+skip_tags: true
+
+environment:
+  matrix:
+    - ruby_version: "193"
+      devkit: C:\Ruby193\DevKit
+    - ruby_version: "200"
+      devkit: C:\Ruby21\DevKit
+    - ruby_version: "200-x64"
+      devkit: C:\Ruby21-x64\DevKit
+    - ruby_version: "21"
+      devkit: C:\Ruby21\DevKit
+    - ruby_version: "21-x64"
+      devkit: C:\Ruby21-x64\DevKit
+    - ruby_version: "22"
+      devkit: C:\Ruby21\DevKit
+    - ruby_version: "22-x64"
+      devkit: C:\Ruby21-x64\DevKit
+
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - "%devkit%\\devkitvars.bat"
+  - gem install bundler --no-rdoc --no-ri
+  - bundler env
+  - bundle install --retry=3
+
+build_script:
+  - bundle exec rake compile
+
+test_script:
+  - bundle exec rake spec

--- a/wdm.gemspec
+++ b/wdm.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'guard-shell'
   gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'devkit'
 end


### PR DESCRIPTION
Appveyor is a CI similar to Travis, except that it's running on windows. I am adding a appveyor.yml [based on this blog post](https://mattbrictson.com/how-to-test-ruby-windows). Here's the running [example from my fork](https://ci.appveyor.com/project/ccoenen/wdm/build/10).