### PR TITLE
Update WDM for newer Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,10 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in wdm.gemspec
 gemspec
+
+group :development do
+  gem 'rake-compiler'
+  gem 'rspec'
+  gem 'guard-rspec'
+  gem 'guard-shell'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -13,5 +13,5 @@ end
 
 desc "Open an irb session preloaded with WDM"
 task :console do
-  sh "irb -rubygems -I lib -r wdm"
+  sh "irb -I lib -r wdm"
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,32 @@
 ---
+image: Visual Studio 2022
 version: '{build}'
 
 skip_tags: true
 
 environment:
   matrix:
-    - ruby_version: "193"
-      devkit: C:\Ruby193\DevKit
-    - ruby_version: "200"
-      devkit: C:\Ruby21\DevKit
-    - ruby_version: "200-x64"
-      devkit: C:\Ruby21-x64\DevKit
-    - ruby_version: "21"
-      devkit: C:\Ruby21\DevKit
-    - ruby_version: "21-x64"
-      devkit: C:\Ruby21-x64\DevKit
-    - ruby_version: "22"
-      devkit: C:\Ruby21\DevKit
-    - ruby_version: "22-x64"
-      devkit: C:\Ruby21-x64\DevKit
+    - ruby_version: "head-x64"
+    - ruby_version: "25"
+    - ruby_version: "30"
+    - ruby_version: "33-x64"
+
+init:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
 
 install:
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - "%devkit%\\devkitvars.bat"
-  - gem install bundler --no-rdoc --no-ri
+  - ps: |
+      if ($env:ruby_version -like "*head*") {
+        $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-$env:ruby_version.exe", "$pwd/ruby-setup.exe")
+        cmd /c ruby-setup.exe /verysilent /currentuser /dir=C:/Ruby$env:ruby_version
+      }
+  - ruby --version
+  - gem --version
+  - ridk version
+  - ridk enable
+  - c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed ${MINGW_PACKAGE_PREFIX}-gcc"
+  - gcc -v
+  - gem install bundler:2.3.27 --conservative --no-doc
   - bundler env
   - bundle install --retry=3
 

--- a/ext/wdm/extconf.rb
+++ b/ext/wdm/extconf.rb
@@ -16,13 +16,10 @@ def windows?
 end
 
 if windows? and
-   have_library("kernel32") and
-   have_header("windows.h") and
-   have_header("ruby.h")    and
-   have_const('HAVE_RUBY_ENCODING_H')
+  have_library("kernel32") and
+  have_header("windows.h")
 then
-   have_func('rb_thread_call_without_gvl')
-   generate_makefile()
+  generate_makefile()
 else
-  generate_dummy_makefile() 
+  generate_dummy_makefile()
 end

--- a/ext/wdm/rb_change.c
+++ b/ext/wdm/rb_change.c
@@ -136,8 +136,6 @@ extract_absolute_path_from_notification(const LPWSTR base_dir, const PFILE_NOTIF
         multibyte_filepath_buffer_size - 1, // -1 because this func takes the chars count, not bytes count
         wdm_rb_enc_utf8);
 
-    OBJ_TAINT(path);
-
     return path;
 }
 

--- a/ext/wdm/rb_monitor.c
+++ b/ext/wdm/rb_monitor.c
@@ -99,6 +99,16 @@ monitor_free(LPVOID param)
     wdm_monitor_free(monitor);
 }
 
+static const rb_data_type_t monitor_data_type = {
+    .wrap_struct_name = "WDM::Monitor",
+    .function = {
+        .dmark = monitor_mark,
+        .dfree = monitor_free,
+        .dsize = NULL,
+    },
+    .flags = 0
+};
+
 static VALUE
 rb_monitor_alloc(VALUE self)
 {
@@ -106,7 +116,7 @@ rb_monitor_alloc(VALUE self)
     WDM_DEBUG("Allocating a new monitor object!");
     WDM_DEBUG("--------------------------------");
 
-    return Data_Wrap_Struct(self, monitor_mark, monitor_free, wdm_monitor_new());
+    return TypedData_Wrap_Struct(self, &monitor_data_type, wdm_monitor_new());
 }
 
 static DWORD
@@ -156,7 +166,7 @@ combined_watch(BOOL recursively, int argc, VALUE *argv, VALUE self)
     // TODO: Maybe raise a more user-friendly error?
     rb_need_block();
 
-    Data_Get_Struct(self, WDM_Monitor, monitor);
+    TypedData_Get_Struct(self, WDM_Monitor, &monitor_data_type, monitor);
 
     EnterCriticalSection(&monitor->lock);
         running = monitor->running;
@@ -467,7 +477,7 @@ rb_monitor_run_bang(VALUE self)
 
     WDM_DEBUG("Running the monitor!");
 
-    Data_Get_Struct(self, WDM_Monitor, monitor);
+    TypedData_Get_Struct(self, WDM_Monitor, &monitor_data_type, monitor);
     already_running = FALSE;
 
     EnterCriticalSection(&monitor->lock);
@@ -529,7 +539,7 @@ rb_monitor_stop(VALUE self)
 {
     WDM_PMonitor monitor;
 
-    Data_Get_Struct(self, WDM_Monitor, monitor);
+    TypedData_Get_Struct(self, WDM_Monitor, &monitor_data_type, monitor);
 
     stop_monitoring(monitor);
 

--- a/ext/wdm/wdm.h
+++ b/ext/wdm/wdm.h
@@ -3,7 +3,7 @@
 // Support Windows 2000 and later,
 // this is needed for 'GetLongPathNameW' (both of the following defines)
 #ifndef WINVER
-#define WINVER 0x0500 
+#define WINVER 0x0500
 #endif
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0500
@@ -14,13 +14,14 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #ifndef VC_EXTRALEAN
-#define VC_EXTRALEAN        
+#define VC_EXTRALEAN
 #endif
 
 #include <Windows.h>
 
 #include <ruby.h>
 #include <ruby/encoding.h>
+#include <ruby/thread.h>
 
 #ifndef WDM_H
 #define WDM_H

--- a/spec/support/fixture_helper.rb
+++ b/spec/support/fixture_helper.rb
@@ -21,7 +21,7 @@ module WDM
 
     ensure
       FileUtils.cd pwd
-      FileUtils.rm_rf(path) if File.exists?(path)
+      FileUtils.rm_rf(path) if File.exist?(path)
     end
   end
 end

--- a/spec/wdm/monitor_spec.rb
+++ b/spec/wdm/monitor_spec.rb
@@ -170,14 +170,6 @@ describe WDM::Monitor do
       end
     end
 
-    it 'marks changed paths as tainted' do
-      result = run_with_fixture(subject) do
-        touch 'file.txt'
-      end
-
-      expect(result.change.path).to be_tainted
-    end
-
     it 'reports changes with absolute paths even when passed relative directory to watch' do
       fixture do |dir|
         relative_dir = Pathname.new(dir).relative_path_from(Pathname.new(Dir.pwd)).to_s

--- a/wdm.gemspec
+++ b/wdm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = '0.1.1'
 
-  gem.required_ruby_version = '>= 1.9.2'
+  gem.required_ruby_version = '>= 2.5'
 
   gem.add_development_dependency 'rake-compiler'
   gem.add_development_dependency 'rspec'

--- a/wdm.gemspec
+++ b/wdm.gemspec
@@ -17,11 +17,4 @@ Gem::Specification.new do |gem|
   gem.version       = '0.1.1'
 
   gem.required_ruby_version = '>= 2.5'
-
-  gem.add_development_dependency 'rake-compiler'
-  gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'guard-rspec'
-  gem.add_development_dependency 'guard-shell'
-  gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'devkit'
 end


### PR DESCRIPTION
This updates several minor topics needed for newer ruby versions.

It also updates the CI to run on newer ruby versions, so that it should be all green like here: https://ci.appveyor.com/project/larskanis/wdm .

Fixes #27
Fixes #28

@Maher4Ever Since you haven't be active since years with this project, may I ask for taking over the maintainership of it? I'm the maintainer of [rubyinstaller](https://github.com/oneclick/rubyinstaller2), so that I have some experience on Windows and interest in the ruby ecosystem on Windows.
